### PR TITLE
Effect handler for surrogate gradient

### DIFF
--- a/forward-torch/reverse.ml
+++ b/forward-torch/reverse.ml
@@ -96,13 +96,17 @@ module Make (P : Prms.T) = struct
   let const p = P.map p ~f:(fun p -> { p; a = Some (zeros_like p) })
 
   (* do we need another function name or it is ok to use grad since it is under Make *)
-  let grad f (x : dual P.p) =
-    let fx = grad f x in
+  let grad
+      (run : (dual P.p -> dual) -> dual P.p -> dual) (* effect handler *)
+      (f   : dual P.p -> dual)
+      (x   : dual P.p)
+    : any t * const t P.p =
+    let fx = run f x in
     let g =
       P.map x ~f:(fun x ->
         match x.a with
         | Some g -> g
         | None -> zeros_like x.p)
     in
-    (fx.p, g)
+    fx.p, g
 end

--- a/forward-torch/reverse.ml
+++ b/forward-torch/reverse.ml
@@ -12,7 +12,8 @@ type _ Stdlib.Effect.t +=
   | Gen2 : ((any t -> any t -> any t) * dual * dual) -> dual Stdlib.Effect.t
 
 let const p = { p; a = None }
-let primal { p; _ } = p
+let primal d = d.p
+let adjoint d = d.a
 let lift1 f a = Stdlib.Effect.perform (Gen1 (f, a))
 let lift2 f a b = Stdlib.Effect.perform (Gen2 (f, a, b))
 let ( + ) a b = lift2 ( + ) a b
@@ -53,54 +54,58 @@ let __prepare a =
 
 let zero_adj p = { p; a = Some (zeros_like p) }
 
-let update_adj adj delta =
-    match adj with
-    | None -> Some delta
-    | Some a -> Some Maths.C.(a + delta)
+(* is it better to use this to update the adjoint externally 
+from other scripts instead of exposing x.a? *)
+let update_adj x delta =
+  x.a
+  <- (match x.a with
+      | None -> Some delta
+      | Some a -> Some Maths.C.(a + delta))
 
-  let grad f x =
-      match f x with
-      | result ->
-        result.a <- Some (C.f 1.);
-        result
-      | effect Gen1 (f, a), k ->
-        let p = f a.p in
-        let o = zero_adj p in
-        let result = Stdlib.Effect.Deep.continue k o in
-        (* use Torch's autodiff to propagate adjoints *)
-        Option.iter o.a ~f:(fun r_bar ->
-          (* prepare a for reverse pass after the continuation *)
-          let a_ = __prepare a in
-          let p = f (any (of_tensor a_)) in
-          let y = Tensor.(sum (to_tensor r_bar * to_tensor p)) in
-          Tensor.backward y;
-          a.a <- update_adj a.a (of_tensor (Tensor.grad a_)));
-        result
-      | effect Gen2 (f, a, b), k ->
-        (* prepare a for reverse pass after the continuation *)
-        let p = f a.p b.p in
-        let o = zero_adj p in
-        let result = Stdlib.Effect.Deep.continue k o in
-        (* use Torch's autodiff to propagate adjoints *)
-        Option.iter o.a ~f:(fun r_bar ->
-          let a_ = __prepare a in
-          let b_ = __prepare b in
-          let p = f (any (of_tensor a_)) (any (of_tensor b_)) in
-          let y = Tensor.(sum (to_tensor r_bar * to_tensor p)) in
-          Tensor.backward y;
-          a.a <- update_adj a.a (of_tensor (Tensor.grad a_));
-          b.a <- update_adj b.a (of_tensor (Tensor.grad b_)));
-        result
+let grad f x =
+  match f x with
+  | result ->
+    result.a <- Some (C.f 1.);
+    result
+  | effect Gen1 (f, a), k ->
+    let p = f a.p in
+    let o = zero_adj p in
+    let result = Stdlib.Effect.Deep.continue k o in
+    (* use Torch's autodiff to propagate adjoints *)
+    Option.iter o.a ~f:(fun r_bar ->
+      (* prepare a for reverse pass after the continuation *)
+      let a_ = __prepare a in
+      let p = f (any (of_tensor a_)) in
+      let y = Tensor.(sum (to_tensor r_bar * to_tensor p)) in
+      Tensor.backward y;
+      update_adj a (of_tensor (Tensor.grad a_)));
+    result
+  | effect Gen2 (f, a, b), k ->
+    (* prepare a for reverse pass after the continuation *)
+    let p = f a.p b.p in
+    let o = zero_adj p in
+    let result = Stdlib.Effect.Deep.continue k o in
+    (* use Torch's autodiff to propagate adjoints *)
+    Option.iter o.a ~f:(fun r_bar ->
+      let a_ = __prepare a in
+      let b_ = __prepare b in
+      let p = f (any (of_tensor a_)) (any (of_tensor b_)) in
+      let y = Tensor.(sum (to_tensor r_bar * to_tensor p)) in
+      Tensor.backward y;
+      update_adj a (of_tensor (Tensor.grad a_));
+      update_adj b (of_tensor (Tensor.grad b_)));
+    result
 
 module Make (P : Prms.T) = struct
   let const p = P.map p ~f:(fun p -> { p; a = Some (zeros_like p) })
 
   (* do we need another function name or it is ok to use grad since it is under Make *)
+  (* idea: let users pass in their own effect handler  *)
   let grad
-      (run : (dual P.p -> dual) -> dual P.p -> dual) (* effect handler *)
-      (f   : dual P.p -> dual)
-      (x   : dual P.p)
-    : any t * const t P.p =
+        (run : (dual P.p -> dual) -> dual P.p -> dual) (* effect handler *)
+        (f : dual P.p -> dual)
+        (x : dual P.p)
+    =
     let fx = run f x in
     let g =
       P.map x ~f:(fun x ->

--- a/forward-torch/reverse.mli
+++ b/forward-torch/reverse.mli
@@ -19,8 +19,9 @@ val tanh : dual -> dual
 val mean : dual -> dual
 val sqr : dual -> dual
 val eval : ('a -> 'b) -> 'a -> 'b
+val grad : ('a -> dual) -> 'a -> dual
 
 module Make (P : Prms.T) : sig
   val const : any t P.p -> dual P.p
-  val grad : (dual P.p -> dual) -> dual P.p -> any t * const t P.p
+  val grad : ((dual P.p -> dual) -> dual P.p -> dual) -> (dual P.p -> dual) -> dual P.p -> any t * const t P.p
 end

--- a/forward-torch/reverse.mli
+++ b/forward-torch/reverse.mli
@@ -5,6 +5,7 @@ type dual
 
 val const : any t -> dual
 val primal : dual -> any t
+val adjoint : dual -> const t option
 val lift1 : (any t -> any t) -> dual -> dual
 val lift2 : (any t -> any t -> any t) -> dual -> dual -> dual
 val ( + ) : dual -> dual -> dual
@@ -19,6 +20,8 @@ val tanh : dual -> dual
 val mean : dual -> dual
 val sqr : dual -> dual
 val eval : ('a -> 'b) -> 'a -> 'b
+val zero_adj: any t -> dual
+val update_adj : dual -> const t -> unit
 val grad : ('a -> dual) -> 'a -> dual
 
 module Make (P : Prms.T) : sig


### PR DESCRIPTION
Users should be able to 
1. define their own effect handler (see `sampling.ml` in sofo-RL) by extending the effect handler (the `grad` function) in `reverse.ml`
2. pass the user-defined effect handler to the `grad function` within the `Make` module in `reverse.ml` to get the function they need for computing the gradient of the loss

